### PR TITLE
Add profile page and loan/refresh handling

### DIFF
--- a/client/app/books/page.tsx
+++ b/client/app/books/page.tsx
@@ -14,7 +14,7 @@ import { BookObjectType } from "@/schemas/book/getBooks";
 import { Navbar } from "@/components/Navbar";
 
 const Books = () => {
-  const { filtered, genreOptions, search, setSearch, genre, setGenre } = useGetBooks();
+  const { filtered, genreOptions, search, setSearch, genre, setGenre, refreshBooks } = useGetBooks();
   const [view, setView] = useState<"grid" | "table">("grid");
   const [sortOrder, setSortOrder] = useState("asc");
 
@@ -23,7 +23,10 @@ const Books = () => {
   );
 
   const handleBorrow = async (book: BookObjectType) => {
-    await borrowBookClient(book.id);
+    const result = await borrowBookClient(book.id);
+    if (result.success) {
+      refreshBooks();
+    }
   };
 
   return (

--- a/client/app/my-loans/page.tsx
+++ b/client/app/my-loans/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   Table,
@@ -17,13 +18,25 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { AlertTriangle, BookOpen, Loader2 } from "lucide-react";
+import { AlertTriangle, BookOpen, Loader2, RotateCcw } from "lucide-react";
 import { useGetMyLoans } from "@/client/state/loan/useGetMyLoans";
+import { returnLoanClient } from "@/client/actions/loan/returnLoanClient";
 import Link from "next/link";
 import { Navbar } from "@/components/Navbar";
+import { useState } from "react";
 
 export default function MyLoansPage() {
-  const { loans, filter, setFilter, loading } = useGetMyLoans();
+  const { loans, filter, setFilter, loading, refreshLoans } = useGetMyLoans();
+  const [returningId, setReturningId] = useState<number | null>(null);
+
+  const handleReturn = async (loanId: number) => {
+    setReturningId(loanId);
+    const result = await returnLoanClient(loanId);
+    if (result.success) {
+      await refreshLoans();
+    }
+    setReturningId(null);
+  };
 
   if (loading) {
     return (
@@ -69,7 +82,7 @@ export default function MyLoansPage() {
           ) : (
             <Card>
               <CardContent className="overflow-x-auto p-0">
-                <Table className="min-w-[500px]">
+                <Table className="min-w-[600px]">
                   <TableHeader>
                     <TableRow>
                       <TableHead>Book</TableHead>
@@ -77,6 +90,7 @@ export default function MyLoansPage() {
                       <TableHead className="hidden md:table-cell">Borrow Date</TableHead>
                       <TableHead>Due Date</TableHead>
                       <TableHead>Status</TableHead>
+                      <TableHead>Actions</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -88,6 +102,7 @@ export default function MyLoansPage() {
                         : isOverdue
                           ? "overdue"
                           : "active";
+                      const isReturning = returningId === loan.id;
 
                       return (
                         <TableRow
@@ -119,6 +134,26 @@ export default function MyLoansPage() {
                               )}
                               {displayStatus}
                             </Badge>
+                          </TableCell>
+                          <TableCell>
+                            {loan.status === "active" ? (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={isReturning}
+                                onClick={() => handleReturn(loan.id)}
+                                className="gap-1.5"
+                              >
+                                {isReturning ? (
+                                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                ) : (
+                                  <RotateCcw className="h-3.5 w-3.5" />
+                                )}
+                                Return
+                              </Button>
+                            ) : (
+                              <span className="text-xs text-muted-foreground">—</span>
+                            )}
                           </TableCell>
                         </TableRow>
                       );

--- a/client/app/profile/page.tsx
+++ b/client/app/profile/page.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  BookOpen,
+  Loader2,
+  RotateCcw,
+  AlertTriangle,
+  User,
+  BookCheck,
+  Clock,
+  BarChart3,
+} from "lucide-react";
+import { Navbar } from "@/components/Navbar";
+import { getUserInfo, type UserInfo } from "@/actions/auth/getUserInfo";
+import { getMyLoansClient } from "@/client/actions/loan/getMyLoansClient";
+import { returnLoanClient } from "@/client/actions/loan/returnLoanClient";
+import { LoanObjectType } from "@/schemas/loan/loans";
+import Link from "next/link";
+
+export default function ProfilePage() {
+  const [user, setUser] = useState<UserInfo>(null);
+  const [loans, setLoans] = useState<LoanObjectType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [returningId, setReturningId] = useState<number | null>(null);
+
+  const fetchData = async () => {
+    const [userInfo, loansResult] = await Promise.all([
+      getUserInfo(),
+      getMyLoansClient(),
+    ]);
+    setUser(userInfo);
+    if (loansResult.success && loansResult.data) {
+      setLoans(loansResult.data);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const handleReturn = async (loanId: number) => {
+    setReturningId(loanId);
+    const result = await returnLoanClient(loanId);
+    if (result.success) {
+      await fetchData();
+    }
+    setReturningId(null);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  const activeLoans = loans.filter((l) => l.status === "active");
+  const returnedLoans = loans.filter((l) => l.status === "returned");
+  const overdueLoans = activeLoans.filter(
+    (l) => new Date(l.due_date) < new Date()
+  );
+
+  const stats = [
+    {
+      label: "Total Borrowed",
+      value: loans.length,
+      icon: BookOpen,
+      color: "text-primary",
+    },
+    {
+      label: "Currently Active",
+      value: activeLoans.length,
+      icon: Clock,
+      color: "text-blue-500",
+    },
+    {
+      label: "Returned",
+      value: returnedLoans.length,
+      icon: BookCheck,
+      color: "text-green-500",
+    },
+    {
+      label: "Overdue",
+      value: overdueLoans.length,
+      icon: AlertTriangle,
+      color: "text-red-500",
+    },
+  ];
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navbar />
+      <div className="mx-auto max-w-5xl px-4 py-8 sm:px-6">
+        <div className="space-y-6">
+          {/* User Info */}
+          <Card>
+            <CardContent className="flex items-center gap-4 p-6">
+              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
+                <User className="h-8 w-8 text-primary" />
+              </div>
+              <div>
+                <h1 className="text-2xl font-bold text-foreground">
+                  {user?.username ?? "User"}
+                </h1>
+                <div className="mt-1 flex items-center gap-2">
+                  <Badge variant={user?.role === "admin" ? "default" : "secondary"}>
+                    {user?.role ?? "user"}
+                  </Badge>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Statistics */}
+          <div>
+            <h2 className="mb-3 flex items-center gap-2 text-lg font-semibold text-foreground">
+              <BarChart3 className="h-5 w-5" />
+              Statistics
+            </h2>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              {stats.map((stat) => (
+                <Card key={stat.label}>
+                  <CardContent className="flex items-center gap-4 p-4">
+                    <stat.icon className={`h-8 w-8 ${stat.color}`} />
+                    <div>
+                      <p className="text-2xl font-bold">{stat.value}</p>
+                      <p className="text-sm text-muted-foreground">{stat.label}</p>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </div>
+
+          {/* Active Loans */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Clock className="h-5 w-5 text-blue-500" />
+                Active Loans ({activeLoans.length})
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              {activeLoans.length === 0 ? (
+                <div className="flex flex-col items-center justify-center gap-2 py-8">
+                  <BookOpen className="h-10 w-10 text-muted-foreground" />
+                  <p className="text-muted-foreground">No active loans</p>
+                  <Link
+                    href="/books"
+                    className="text-sm text-primary hover:underline"
+                  >
+                    Browse the catalog
+                  </Link>
+                </div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Book</TableHead>
+                        <TableHead>Author</TableHead>
+                        <TableHead>Borrow Date</TableHead>
+                        <TableHead>Due Date</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead>Actions</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {activeLoans.map((loan) => {
+                        const isOverdue = new Date(loan.due_date) < new Date();
+                        const isReturning = returningId === loan.id;
+
+                        return (
+                          <TableRow
+                            key={loan.id}
+                            className={isOverdue ? "bg-destructive/5" : ""}
+                          >
+                            <TableCell className="font-medium">
+                              {loan.book_title ?? "Unknown"}
+                            </TableCell>
+                            <TableCell>{loan.book_author ?? "Unknown"}</TableCell>
+                            <TableCell>
+                              {new Date(loan.loan_date).toLocaleDateString()}
+                            </TableCell>
+                            <TableCell>
+                              {new Date(loan.due_date).toLocaleDateString()}
+                            </TableCell>
+                            <TableCell>
+                              <Badge variant={isOverdue ? "destructive" : "accent"}>
+                                {isOverdue && (
+                                  <AlertTriangle className="mr-1 h-3 w-3" />
+                                )}
+                                {isOverdue ? "overdue" : "active"}
+                              </Badge>
+                            </TableCell>
+                            <TableCell>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={isReturning}
+                                onClick={() => handleReturn(loan.id)}
+                                className="gap-1.5"
+                              >
+                                {isReturning ? (
+                                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                ) : (
+                                  <RotateCcw className="h-3.5 w-3.5" />
+                                )}
+                                Return
+                              </Button>
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Loan History */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <BookCheck className="h-5 w-5 text-green-500" />
+                Loan History ({returnedLoans.length})
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="p-0">
+              {returnedLoans.length === 0 ? (
+                <div className="flex flex-col items-center justify-center gap-2 py-8">
+                  <BookOpen className="h-10 w-10 text-muted-foreground" />
+                  <p className="text-muted-foreground">No returned books yet</p>
+                </div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Book</TableHead>
+                        <TableHead>Author</TableHead>
+                        <TableHead>Borrow Date</TableHead>
+                        <TableHead>Return Date</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {returnedLoans.map((loan) => (
+                        <TableRow key={loan.id}>
+                          <TableCell className="font-medium">
+                            {loan.book_title ?? "Unknown"}
+                          </TableCell>
+                          <TableCell>{loan.book_author ?? "Unknown"}</TableCell>
+                          <TableCell>
+                            {new Date(loan.loan_date).toLocaleDateString()}
+                          </TableCell>
+                          <TableCell>
+                            {loan.return_date
+                              ? new Date(loan.return_date).toLocaleDateString()
+                              : "—"}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/proxy.ts
+++ b/client/proxy.ts
@@ -23,7 +23,7 @@ function decodeJWTPayload(token: string): Record<string, unknown> | null {
 }
 
 // Routes that require authentication
-const protectedRoutes = ["/my-loans", "/admin"];
+const protectedRoutes = ["/my-loans", "/profile", "/admin"];
 // Routes only accessible when NOT logged in
 const authRoutes = ["/login", "/register"];
 
@@ -59,5 +59,5 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/admin/:path*", "/my-loans/:path*", "/login", "/register"],
+  matcher: ["/admin/:path*", "/my-loans/:path*", "/profile/:path*", "/login", "/register"],
 };

--- a/client/src/client/state/book/useGetBooks.ts
+++ b/client/src/client/state/book/useGetBooks.ts
@@ -3,7 +3,7 @@
 import { deleteBookClient } from "@/client/actions/book/deleteBookClient";
 import { getBooksClient } from "@/client/actions/book/getBooksClient";
 import { BookObjectType, GetBooksResponseType } from "@/schemas/book/getBooks";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export const useGetBooks = () => {
     const [books, setBooks] = useState<GetBooksResponseType>([]);
@@ -11,17 +11,16 @@ export const useGetBooks = () => {
     const [genre, setGenre] = useState("All");
     const [deleteId, setDeleteId] = useState<number | null>(null);
 
-    useEffect(() => {
-        const handleGetBooks = async () => {
-            const result = await getBooksClient();
-
-            if (result.success && result.data) {
-                setBooks(result.data);
-            }
-        };
-
-        handleGetBooks();
+    const fetchBooks = useCallback(async () => {
+        const result = await getBooksClient();
+        if (result.success && result.data) {
+            setBooks(result.data);
+        }
     }, []);
+
+    useEffect(() => {
+        fetchBooks();
+    }, [fetchBooks]);
 
     const filtered = books.filter((b) => {
         const matchSearch =
@@ -63,5 +62,6 @@ export const useGetBooks = () => {
         setDeleteId,
         handleDelete,
         setSelectedBookForDelete,
+        refreshBooks: fetchBooks,
     };
 };

--- a/client/src/client/state/loan/useGetMyLoans.ts
+++ b/client/src/client/state/loan/useGetMyLoans.ts
@@ -2,26 +2,26 @@
 
 import { getMyLoansClient } from "@/client/actions/loan/getMyLoansClient";
 import { LoanObjectType } from "@/schemas/loan/loans";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export const useGetMyLoans = () => {
     const [loans, setLoans] = useState<LoanObjectType[]>([]);
     const [filter, setFilter] = useState("all");
     const [loading, setLoading] = useState(true);
 
-    useEffect(() => {
-        const fetchLoans = async () => {
-            setLoading(true);
-            const result = await getMyLoansClient();
+    const fetchLoans = useCallback(async () => {
+        setLoading(true);
+        const result = await getMyLoansClient();
 
-            if (result.success && result.data) {
-                setLoans(result.data);
-            }
-            setLoading(false);
-        };
-
-        fetchLoans();
+        if (result.success && result.data) {
+            setLoans(result.data);
+        }
+        setLoading(false);
     }, []);
+
+    useEffect(() => {
+        fetchLoans();
+    }, [fetchLoans]);
 
     const filtered = loans.filter((l) => {
         if (filter === "all") return true;
@@ -36,5 +36,6 @@ export const useGetMyLoans = () => {
         filter,
         setFilter,
         loading,
+        refreshLoans: fetchLoans,
     };
 };

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Library, BookOpen, FileText, LogOut, Shield } from "lucide-react";
+import { Library, BookOpen, FileText, LogOut, Shield, User } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { getUserInfo, type UserInfo } from "@/actions/auth/getUserInfo";
 import { logout } from "@/actions/auth/logout";
@@ -24,6 +24,7 @@ export function Navbar() {
   const navLinks = [
     { href: "/books", label: "Catalog", icon: BookOpen },
     { href: "/my-loans", label: "My Loans", icon: FileText },
+    { href: "/profile", label: "Profile", icon: User },
   ];
 
   return (

--- a/client/src/schemas/loan/loans.ts
+++ b/client/src/schemas/loan/loans.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 
+// Schema for loan objects from raw SQL JOINs (snake_case fields)
 export const LoanObjectSchema = z.object({
     id: z.number().int().positive(),
     user_id: z.number().int().positive().optional(),
@@ -15,6 +16,19 @@ export const LoanObjectSchema = z.object({
 
 export type LoanObjectType = z.infer<typeof LoanObjectSchema>;
 
+// Schema for loan objects from Loan.toJSON() (camelCase fields)
+export const LoanCamelCaseSchema = z.object({
+    id: z.number().int().positive(),
+    userId: z.number().int().positive(),
+    bookId: z.number().int().positive(),
+    loanDate: z.string(),
+    dueDate: z.string(),
+    returnDate: z.string().nullable(),
+    status: z.enum(["active", "returned"]),
+});
+
+export type LoanCamelCaseType = z.infer<typeof LoanCamelCaseSchema>;
+
 export const GetActiveLoansResponseSchema = z.array(LoanObjectSchema);
 export type GetActiveLoansResponseType = z.infer<typeof GetActiveLoansResponseSchema>;
 
@@ -26,11 +40,11 @@ export type GetMyLoansResponseType = z.infer<typeof GetMyLoansResponseSchema>;
 
 export const ReturnLoanResponseSchema = z.object({
     message: z.string(),
-    loan: LoanObjectSchema,
+    loan: LoanCamelCaseSchema,
 });
 export type ReturnLoanResponseType = z.infer<typeof ReturnLoanResponseSchema>;
 
-export const BorrowBookResponseSchema = LoanObjectSchema;
+export const BorrowBookResponseSchema = LoanCamelCaseSchema;
 export type BorrowBookResponseType = z.infer<typeof BorrowBookResponseSchema>;
 
 export const BorrowBookRequestSchema = z.object({


### PR DESCRIPTION
Add a new client profile page with user stats, active loans, and loan history including in-UI return actions and loading state. Expose refresh functions from useGetBooks and useGetMyLoans (useCallback + useEffect) and trigger refresh after borrow/return to keep lists in sync. Update My Loans page to include an Actions column, return button with spinner, wider table, and optimistic loading state. Add /profile to protected routes and middleware matcher and add Profile link to the Navbar. Update loan schemas to include a camelCase loan shape and switch Borrow/Return response types to the camelCase schema.