### PR TITLE
fix: use runtime API_URL env var to fix 'Invalid response format' on …

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,1 +1,5 @@
+# Server-side API URL (used at runtime - set this on Render/production)
+API_URL=https://your-backend/api
+
+# Client-side API URL (baked in at build time - only for browser-side calls)
 NEXT_PUBLIC_API_URL=https://your-backend/api

--- a/client/src/external/http.ts
+++ b/client/src/external/http.ts
@@ -85,7 +85,7 @@ export async function http<T>({
   schema,
   token
 }: HttpFunctionConfig<T>): Promise<ApiResponse<T>> {
-  const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api';
+  const baseUrl = process.env.API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api';
   const url = `${baseUrl}${path}`;
   const requestId = createRequestId();
   const startTime = Date.now();


### PR DESCRIPTION
…Render

NEXT_PUBLIC_* vars are inlined at build time in Next.js, so they were undefined on Render (never set during Docker build). The http() function is server-side only, so we now use API_URL which is read at runtime.

Set API_URL=https://ime-proekt-server.onrender.com/api on Render dashboard.